### PR TITLE
Fix for linter in build step for template.

### DIFF
--- a/src/pages/page-section1.html
+++ b/src/pages/page-section1.html
@@ -93,7 +93,7 @@
 
       _tabChanged: function(tab) {
         var tabs = ['tab1', 'tab2'];
-        if (tabs.indexOf(tab) == -1) {
+        if (tabs.indexOf(tab) === -1) {
           this.fire('404');
         }
       }


### PR DESCRIPTION
The linter gets hung up on this.  If there's a reason strict type comparisons shouldn't be enforced here, let me know.